### PR TITLE
Pass image to parseRectFragment for percent format

### DIFF
--- a/src/AnnotationStore.js
+++ b/src/AnnotationStore.js
@@ -20,7 +20,7 @@ import {
   const isBox = annotation.targets[0].selector.type === 'FragmentSelector';
 
   if (isBox) {
-    const {x,y,w,h} = parseRectFragment(annotation);
+    const {x,y,w,h} = parseRectFragment(annotation, image);
 
     return {
       minX: x, 


### PR DESCRIPTION
Hi @rsimon, just wanted to pass along this fix for a bug that was preventing us (in the Princeton Geniza Project) from upgrading Annotorious-OSD above v2.7.6.

`parseRectFragment` was never receiving the image as a second argument, so fragment selectors using the `percent` format would fail on `image.naturalWidth` (as `image` was undefined).