### PR TITLE
Simplify moveHandler (#186)

### DIFF
--- a/src/OSDAnnotationLayer.js
+++ b/src/OSDAnnotationLayer.js
@@ -141,14 +141,11 @@ export class AnnotationLayer extends EventEmitter {
   _initDrawingTools = gigapixelMode => {
     let started = false;
     
-    let firstDragDone = false;
-
     let dragging = false;
 
     this.tools = new DrawingTools(this.g, this.config, this.env);
 
     this.tools.on('complete', shape => {
-      firstDragDone = false;
       this.onDrawingComplete(shape);
     });
 
@@ -179,18 +176,16 @@ export class AnnotationLayer extends EventEmitter {
         if (this.tools.current.isDrawing) {
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
  
-          if (!evt.buttons || !firstDragDone) {
-            evt.originalEvent.stopPropagation();
+          evt.originalEvent.stopPropagation();
 
-            this.tools.current.onMouseMove(x, y, evt.originalEvent);
+          this.tools.current.onMouseMove(x, y, evt.originalEvent);
 
-            if (!started) {
-              this.emit('startSelection', { x , y });
-              started = true;
-            }
-          } else {
-            if (!dragging && this.tools.current.onDragStart)
-              this.tools.current.onDragStart(x, y, evt.originalEvent);
+          if (!started) {
+            this.emit('startSelection', { x , y });
+            started = true;
+          }
+          if (!dragging && this.tools.current.onDragStart) {
+            this.tools.current.onDragStart(x, y, evt.originalEvent);
 
             dragging = true;
           }
@@ -199,8 +194,6 @@ export class AnnotationLayer extends EventEmitter {
 
       releaseHandler: evt => {
         if (this.tools.current.isDrawing) {
-          firstDragDone = true;
-
           // continue in dragging mode if moveHandler has not been fired
           // if (!started) return;
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
@@ -246,8 +239,6 @@ export class AnnotationLayer extends EventEmitter {
       if (evt.key.toLowerCase() === hotkey && !this.tools.current.isDrawing) {
         this.mouseTracker.enabled = inverted;
         this.tools.current.enabled = inverted;
-
-        firstDragDone = false;
       }
     };
         

--- a/src/OSDAnnotationLayer.js
+++ b/src/OSDAnnotationLayer.js
@@ -141,11 +141,14 @@ export class AnnotationLayer extends EventEmitter {
   _initDrawingTools = gigapixelMode => {
     let started = false;
     
+    let firstDragDone = false;
+
     let dragging = false;
 
     this.tools = new DrawingTools(this.g, this.config, this.env);
 
     this.tools.on('complete', shape => {
+      firstDragDone = false;
       this.onDrawingComplete(shape);
     });
 
@@ -176,7 +179,9 @@ export class AnnotationLayer extends EventEmitter {
         if (this.tools.current.isDrawing) {
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
  
-          evt.originalEvent.stopPropagation();
+          if (!firstDragDone) {
+            evt.originalEvent.stopPropagation();
+          }
 
           this.tools.current.onMouseMove(x, y, evt.originalEvent);
 
@@ -197,7 +202,10 @@ export class AnnotationLayer extends EventEmitter {
           // continue in dragging mode if moveHandler has not been fired
           // if (!started) return;
           const { x , y } = this.tools.current.getSVGPoint(evt.originalEvent);
-          if (started) this.emit('endSelection', { x , y });
+          if (started) { 
+            this.emit('endSelection', { x , y });
+            firstDragDone = true;
+          }
           this.tools.current.onMouseUp(x, y, evt.originalEvent);
 
           if (dragging && this.tools.current.onDragEnd)
@@ -239,6 +247,7 @@ export class AnnotationLayer extends EventEmitter {
       if (evt.key.toLowerCase() === hotkey && !this.tools.current.isDrawing) {
         this.mouseTracker.enabled = inverted;
         this.tools.current.enabled = inverted;
+        firstDragDone = false;
       }
     };
         


### PR DESCRIPTION
Hi @rsimon! Wanted to pass along a fix for #186 working locally in my application. This PR likely needs more careful attention than my other ones since it changes a core drawing functionality and might not work outside of my context.

Notes:
- I'm only testing this with the polygon and rectangle tool in a specific application where we've disabled clicking on the canvas after you finish a drawing (until you save or cancel it), so it's possible this is broken in any other context.
- I wasn't certain what the purpose of `firstDragDone` was, but I needed to remove the one check for it to get this working. Maybe that breaks something else!
- Like I mentioned in #186, `evt.buttons` seems to always be `1` whenever I'm able to fire this event.
- Though none of the Annotorious 2.x tools have dragstart or dragend event handlers, I left them in just in case it's meant for other tool implementations.